### PR TITLE
Fixes HR -8 : EmployeeDAOImpl 미구현으로 인한 오류 해결

### DIFF
--- a/src/main/java/com/woosan/hr_system/HrSystemApplication.java
+++ b/src/main/java/com/woosan/hr_system/HrSystemApplication.java
@@ -2,8 +2,10 @@ package com.woosan.hr_system;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = "com.woosan.hr_system")
 public class HrSystemApplication {
 
 	public static void main(String[] args) {
@@ -11,3 +13,4 @@ public class HrSystemApplication {
 	}
 
 }
+

--- a/src/main/java/com/woosan/hr_system/employee/dao/DepartmentDAO.java
+++ b/src/main/java/com/woosan/hr_system/employee/dao/DepartmentDAO.java
@@ -1,4 +1,0 @@
-package com.woosan.hr_system.employee.dao;
-
-public class DepartmentDAO {
-}

--- a/src/main/java/com/woosan/hr_system/employee/dao/EmployeeDAOImpl.java
+++ b/src/main/java/com/woosan/hr_system/employee/dao/EmployeeDAOImpl.java
@@ -1,0 +1,42 @@
+package com.woosan.hr_system.employee.dao;
+
+import com.woosan.hr_system.employee.model.Employee;
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class EmployeeDAOImpl implements EmployeeDAO {
+
+    @Autowired
+    private SqlSession sqlSession;
+
+    private static final String NAMESPACE = "com.woosan.hr_system.employee.dao.EmployeeDAO";
+
+    @Override
+    public Employee getEmployeeById(String employeeId) {
+        return sqlSession.selectOne(NAMESPACE + ".getEmployeeById", employeeId);
+    }
+
+    @Override
+    public List<Employee> getAllEmployees() {
+        return sqlSession.selectList(NAMESPACE + ".getAllEmployees");
+    }
+
+    @Override
+    public void insertEmployee(Employee employee) {
+        sqlSession.insert(NAMESPACE + ".insertEmployee", employee);
+    }
+
+    @Override
+    public void updateEmployee(Employee employee) {
+        sqlSession.update(NAMESPACE + ".updateEmployee", employee);
+    }
+
+    @Override
+    public void deleteEmployee(String employeeId) {
+        sqlSession.delete(NAMESPACE + ".deleteEmployee", employeeId);
+    }
+}

--- a/src/main/java/com/woosan/hr_system/employee/dao/PositionDAO.java
+++ b/src/main/java/com/woosan/hr_system/employee/dao/PositionDAO.java
@@ -1,4 +1,0 @@
-package com.woosan.hr_system.employee.dao;
-
-public class PositionDAO {
-}


### PR DESCRIPTION
### 개요
이 PR은 `feature/employee` 브랜치의 `EmployeeDAO` 미구현으로 인한 오류를 해결합니다. 
MyBatis를 사용하여 `EmployeeDAO` 인터페이스의 CRUD 메서드를 구현하였습니다.

### 변경 사항
- `EmployeeDAOImpl` 구현
  - `getEmployeeById`: 특정 사원 정보를 조회하는 메서드 구현
  - `getAllEmployees`: 모든 사원 정보를 조회하는 메서드 구현
  - `insertEmployee`: 사원 정보를 등록하는 메서드 구현
  - `updateEmployee`: 사원 정보를 수정하는 메서드 구현
  - `deleteEmployee`: 사원 정보를 삭제하는 메서드 구현
- MyBatis 매퍼 XML 파일 추가 및 설정

### 테스트 방법
1. 로컬 환경에서 애플리케이션을 실행합니다.
2. 다양한 CRUD 작업 (Create, Read, Update, Delete)이 정상적으로 작동하는지 확인합니다.
   - 사원 정보를 추가하고 (`insertEmployee`)
   - 특정 사원 정보를 조회하며 (`getEmployeeById`)
   - 모든 사원 정보를 조회하고 (`getAllEmployees`)
   - 사원 정보를 업데이트하며 (`updateEmployee`)
   - 사원 정보를 삭제합니다 (`deleteEmployee`)

### 관련 이슈
- HR-8: Employee CRUD 기능 미구현 이슈
